### PR TITLE
fix trigger search when switching tab on Linux

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -73,7 +73,7 @@ function updateKeyword(key) {
 
 function handleKeyPress(e) {
   var key = e.keyCode || e.which;
-  if (e.ctrlKey || e.metaKey) {
+  if (e.ctrlKey || e.metaKey || e.altKey) {
     // ignore key combination
     return
   }


### PR DESCRIPTION
In Linux, the browser uses alt + numbers to switch tab pages. 
It is necessary to determine whether the alt key is pressed.