### PR TITLE
fix: merge upstream fixes and improvements (PR #7 #8 #9 #10 #14)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 package-lock.json
 dist/
 data.json
+node_modules
+.reasonix/

--- a/404.html
+++ b/404.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <title>SUI2</title>
+  <title>{{title}}</title>
   <meta charset="utf-8">
-  <meta name="description" content="a startpage for your server and / or new tab page">
+  <meta name="description" content="{{description}}">
   <meta content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport" />
   <link rel="shortcut icon" href="/icon-512.png" type="image/png">
   <style>

--- a/data.example.json
+++ b/data.example.json
@@ -1,4 +1,6 @@
 {
+  "title": "SUI2",
+  "description": "a startpage for your server and / or new tab page",
   "apps" : [
     {
       "name": "Cloud",

--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
 
 <head>
-  <title>SUI2</title>
+  <title>{{title}}</title>
   <meta charset="utf-8">
-  <meta name="description" content="a startpage for your server and / or new tab page">
+  <meta name="description" content="{{description}}">
   <meta content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport" />
   <link rel="shortcut icon" href="/icon-512.png" type="image/png">
   <link rel="stylesheet" href="/scss/styles.scss" />
@@ -39,7 +39,7 @@
       </div>
 
       <footer>
-        Project: <a href="https://github.com/reorx/sui2">reorx/suis</a>
+        Project: <a href="https://github.com/reorx/sui2">reorx/sui2</a>
         Icons: <a href="https://icon-sets.iconify.design/mdi/">Iconify MDI</a>
       </footer>
     </div>
@@ -61,7 +61,7 @@
         {{#items}}
 
         <div class="apps_item_wrap">
-          <a href="{{url}}" target="_blank" class="apps_item">
+          <a href="{{url}}" target="{{#if target}}{{target}}{{else}}_blank{{/if}}" class="apps_item">
             <div class="apps_icon">
             {{{iconify icon}}}
             </div>

--- a/js/search.js
+++ b/js/search.js
@@ -73,7 +73,7 @@ function updateKeyword(key) {
 
 function handleKeyPress(e) {
   var key = e.keyCode || e.which;
-  if (e.ctrlKey || e.metaKey) {
+  if (e.ctrlKey || e.metaKey || e.altKey) {
     // ignore key combination
     return
   }

--- a/live-server/app.js
+++ b/live-server/app.js
@@ -54,7 +54,8 @@ if (!fs.existsSync(dataFilePath)) {
   fs.copyFileSync(path.resolve(buildDir, 'data.example.json'), dataFilePath)
 }
 
-if (!fs.existsSync(path.resolve(outDir, 'index.html'))) {
+if (!fs.existsSync(path.resolve(outDir, 'index.html')) &&
+    !fs.existsSync(path.resolve(outDir, '404.html'))) {
   console.log('run initial build')
   buildStartpage((err, stdout, stderr) => {
     if (err) {
@@ -116,6 +117,10 @@ app.use('/', express.static(outDir))
 app.use('/preview', express.static(outDir))
 
 app.use('/editor', express.static(editorDir))
+
+app.use('*', function(req, res){
+  res.status(404).sendFile(path.resolve(outDir, '404.html'))
+})
 
 app.listen(port, () => {
   console.log(`live-server app listening on port ${port}`)

--- a/live-server/editor/index.html
+++ b/live-server/editor/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -12,7 +12,7 @@
   <div class="main">
     <div class="left">
       <div class="header">
-        <h2>SUI Live Editor</h2>
+        <h2>SUI2 Live Editor</h2>
         <button class="fn-build">Build</button>
       </div>
       <div class="editor"></div>

--- a/live-server/vite.config.js
+++ b/live-server/vite.config.js
@@ -9,6 +9,7 @@ export default defineConfig({
     rolupOptions: {
       input: {
         main: resolve(__dirname, 'index.html'),
+        page404: resolve(__dirname, '404.html'),
       },
     },
   },

--- a/scss/styles.scss
+++ b/scss/styles.scss
@@ -19,7 +19,7 @@ body {
   margin: 0;
   padding: 0;
   -webkit-font-smoothing: antialiased;
-  width: 100vw;
+  width: 100%;
 }
 
 *,
@@ -234,7 +234,7 @@ a:hover {
 
   .apps_loop {
     grid-template-columns: 1fr 1fr 1fr;
-    width: 100vw;
+    width: 100%;
   }
 
   #links_loop {
@@ -258,7 +258,7 @@ a:hover {
     grid-column-gap: 0px;
     grid-row-gap: 0px;
     grid-template-columns: 1fr 1fr;
-    width: 100vw;
+    width: 100%;
   }
 
   #links_loop {

--- a/vite.config.js
+++ b/vite.config.js
@@ -60,6 +60,7 @@ export default defineConfig({
     rollupOptions: {
       input: {
         main: resolve(__dirname, 'index.html'),
+        page404: resolve(__dirname, '404.html'),
       },
     },
   },


### PR DESCRIPTION
## 概述

将 5 个上游 PR 的修复与改进整合为单个 squash 提交（这些 PR 均未合并到 master）。

### 包含的改动

- **fix (PR #7)**：`scss/styles.scss` 三处 `width: 100vw` → `width: 100%`，修复小屏设备与 Windows 浏览器下由垂直滚动条导致的水平滚动条问题。
- **fix (PR #14)**：`js/search.js` 组合键判断增加 `altKey`，避免 Linux 下用 Alt+数字切换标签页时误触发搜索。
- **feat (PR #9)**：`<title>` / `<meta description>` 支持通过数据文件自定义（`{{title}}` / `{{description}}`），`404.html` 移入 vite 构建管线；顺带修正 footer 中 "reorx/suis" → "reorx/sui2" 拼写。
- **feat (PR #8，改进版)**：apps 链接支持自定义 `target`，但用 handlebars `{{#if target}}...{{else}}_blank{{/if}}` 兜底，未配置时保持原 `_blank` 行为，避免行为回归。
- **improve (PR #10)**：live-server 对未知路由返回 `404.html`。

### 未包含

- **PR #12**（误提交个人/内部数据 `data.json` 至公共仓库，不应合并）。

### 验证

- `npm run build` 构建通过（含 `404.html` 产物）。
- 产物中 `<title>SUI2</title>`、apps 链接 `target="_blank"`（未配置时）与 `target="_self"`（配置时）渲染均正确。
